### PR TITLE
Fix BlankSlate requirement failure with latest Jbuilder version

### DIFF
--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -49,11 +49,11 @@ module Tilt
   register Tilt::JbuilderTemplate, 'jbuilder'
 end
 
-class Jbuilder < BlankSlate
+class Jbuilder
   def partial!(options, locals = {})
-    path = Pathname.new(options)
+    path = ::Pathname.new(options)
     locals.merge! :json => self
-    template = Tilt::JbuilderTemplate.new("#{path.dirname.to_s}/_#{path.basename}.json.jbuilder")
+    template = ::Tilt::JbuilderTemplate.new("#{path.dirname.to_s}/_#{path.basename}.json.jbuilder")
     template.render(nil, locals)
   end
 end


### PR DESCRIPTION
Latest jbuilder gem version no longer uses BlankSlate and has replaced
it with BasicObject. See:
https://github.com/rails/jbuilder/commit/c438bf356439fcf6c9503c00de21b4381cf965bf
