### PR TITLE
Added view_path option

### DIFF
--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -9,13 +9,14 @@ module Tilt
 
     def partial!(options, locals = {})
       locals.merge! :json => self
-      template = ::Tilt::JbuilderTemplate.new(fetch_partial_path(options.to_s))
+      view_path = @scope.instance_variable_get('@_jbuilder_view_path')
+      template = ::Tilt::JbuilderTemplate.new(fetch_partial_path(options.to_s, view_path), nil, view_path: view_path)
       template.render(@scope, locals)
     end
 
     private
-    def fetch_partial_path(file)
-      view_path =
+    def fetch_partial_path(file, view_path)
+      view_path ||=
         if defined?(::Sinatra) && @scope.respond_to?(:settings)
           @scope.settings.views
         else
@@ -70,6 +71,8 @@ module Tilt
 
     private
     def set_locals(locals, scope, context)
+      view_path = options.delete(:view_path)
+      scope.send(:instance_variable_set, '@_jbuilder_view_path', view_path)
       scope.send(:instance_variable_set, '@_jbuilder_locals', locals)
       scope.send(:instance_variable_set, '@_tilt_data', data)
       set_locals = locals.keys.map { |k| "#{k} = @_jbuilder_locals[#{k.inspect}]" }.join("\n")
@@ -79,4 +82,3 @@ module Tilt
 
   register Tilt::JbuilderTemplate, 'jbuilder'
 end
-

--- a/spec/tilt-jbuilder_spec.rb
+++ b/spec/tilt-jbuilder_spec.rb
@@ -39,4 +39,9 @@ describe Tilt::JbuilderTemplate do
     template = Tilt::JbuilderTemplate.new { "json.partial! 'spec/partial', last_name: 'Smith'" }
     "{\"last_name\":\"Smith\"}".should == template.render
   end
+
+  it "should evaluate partials with view_path" do
+    template = Tilt::JbuilderTemplate.new(nil, nil, view_path: 'spec') { "json.partial! '/partial', last_name: 'Smith'" }
+    "{\"last_name\":\"Smith\"}".should == template.render
+  end
 end

--- a/tilt-jbuilder.gemspec
+++ b/tilt-jbuilder.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'tilt'
   gem.add_dependency 'jbuilder'
-  gem.add_dependency 'sinatra'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rack-test'
+  gem.add_development_dependency 'sinatra'
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I've created a [grape-jbuilder gem](http://github.com/milkcocoa/grape-jbuilder) for using Jbuilder in Grape.
This gem uses this tilt-jbuilder gem, but to support Jbuilder partial! method, I needed I had tilt-jbuidler supported view's root path.
So, I introduced a view_path option in tilt-jbuilder.
