### PR TITLE
Explicitly require tilt

### DIFF
--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -1,3 +1,4 @@
+require 'tilt'
 require 'jbuilder'
 
 module Tilt


### PR DESCRIPTION
Otherwise, the end-developer needs to require tilt explicitly in their own application.
