### PR TITLE
json.cache! is now transparently ignored and its contents yielded.

### DIFF
--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -15,6 +15,11 @@ module Tilt
       template.render(@scope, locals)
     end
 
+    # for now caching is not supported, but at least we can transparently ignore it
+    def cache!(key=nil, options={}, &block)
+      yield
+    end
+
     private
     def fetch_partial_path(file, view_path)
       view_path ||= ::Dir.pwd

--- a/spec/tilt-jbuilder_spec.rb
+++ b/spec/tilt-jbuilder_spec.rb
@@ -27,6 +27,11 @@ describe Tilt::JbuilderTemplate do
     "{\"author\":\"Anthony\"}".should == template.render(scope)
   end
 
+  it "should ignore cache!" do
+    template = Tilt::JbuilderTemplate.new { "json.cache! { json.author name }" }
+    "{\"author\":\"Anthony\"}".should == template.render(Object.new, :name => 'Anthony')
+  end
+
   it "should evaluate block style templates" do
     template = Tilt::JbuilderTemplate.new do |json|
       lambda do |json|


### PR DESCRIPTION
To provide better compatibility with shared templates. At some point I would like to make caching actually work. 