### PR TITLE
add source filename info whe evaluating .jbuilder files

### DIFF
--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -49,7 +49,7 @@ module Tilt
         if data.kind_of?(Proc)
           return data.call(::Tilt::Jbuilder.new(scope))
         else
-          eval(data, context)
+          file.is_a?(String) ? eval(data, context, file) : eval(data, context)
         end
       end
     end

--- a/spec/support/views/invalid.jbuilder
+++ b/spec/support/views/invalid.jbuilder
@@ -1,0 +1,2 @@
+json.author "Anthony"
+json.trigger_error_on_this_line nil.name

--- a/spec/tilt-jbuilder_spec.rb
+++ b/spec/tilt-jbuilder_spec.rb
@@ -5,6 +5,15 @@ describe Tilt::JbuilderTemplate do
     Tilt::JbuilderTemplate.should == Tilt['test.jbuilder']
   end
 
+  it "contains information about source file when error in .jbuilder file" do
+    template = Tilt::JbuilderTemplate.new(File.join('spec', 'support', 'views', 'invalid.jbuilder'))
+    begin
+      template.render
+    rescue => e
+      expect(e.backtrace.join).to include 'invalid.jbuilder:2' # we should see error on line 2 in file invalid.jbuilder in stacktrace
+    end
+  end
+
   it "should evaluate the template on #render" do
     template = Tilt::JbuilderTemplate.new { "json.author 'Anthony'" }
     "{\"author\":\"Anthony\"}".should == template.render


### PR DESCRIPTION
It's quite hard to find errors in .jbuilder files. When there is an error in it, the stacktrace looks like:

```
NoMethodError - undefined method `id' for nil:NilClass:
  tilt-jbuilder (0.6.0) lib/tilt/jbuilder.rb:109:in `block (4 levels) in evaluate'
  ...
```

Where line 109 doesn't even exist in jbuilder.rb file. No clue where the error can be... :-(

With my modification the stacktrace looks like:

```
NoMethodError - undefined method `id' for nil:NilClass:
  app/views/api/product.jbuilder:63:in `block (4 levels) in evaluate'
  ...
```

we now know exactly where the error is!
