### PR TITLE
NameError - undefined local variable or method

### DIFF
--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -22,8 +22,8 @@ module Tilt
       end
 
       view_path = @scope.instance_variable_get('@_jbuilder_view_path')
-      @template = ::Tilt::JbuilderTemplate.new(fetch_partial_path(options[:partial].to_s, view_path), nil, view_path: view_path)
-      render_partial_with_options options
+      template = ::Tilt::JbuilderTemplate.new(fetch_partial_path(options[:partial].to_s, view_path), nil, view_path: view_path)
+      render_partial_with_options template, options
     end
 
     def array!(collection = [], *attributes, &block)
@@ -53,7 +53,7 @@ module Tilt
       partial_file.join("/")
     end
 
-    def render_partial_with_options(options)
+    def render_partial_with_options(template, options)
       options[:locals] ||= {}
       if options[:as] && options.key?(:collection)
         collection = options.delete(:collection)
@@ -61,16 +61,16 @@ module Tilt
         array! collection do |member|
           member_locals = locals.clone
           member_locals.merge! options[:as] => member
-          render_partial member_locals
+          render_partial template, member_locals
         end
       else
-        render_partial options[:locals]
+        render_partial template, options[:locals]
       end
     end
 
-    def render_partial(options)
+    def render_partial(template, options)
       options.merge! json: self
-      @template.render @scope, options
+      template.render @scope, options
     end
   end
 

--- a/spec/templates/_profile.json.jbuilder
+++ b/spec/templates/_profile.json.jbuilder
@@ -1,0 +1,1 @@
+json.name profile[:name]

--- a/spec/templates/_user.json.jbuilder
+++ b/spec/templates/_user.json.jbuilder
@@ -1,0 +1,4 @@
+json.id user[:id]
+json.profile do |json|
+  json.partial! 'spec/templates/profile', profile: user[:profile]
+end

--- a/spec/tilt-jbuilder_spec.rb
+++ b/spec/tilt-jbuilder_spec.rb
@@ -90,5 +90,10 @@ describe Tilt::JbuilderTemplate do
       let(:template_body) { "json.array! ['foo', 'bar'], partial: 'spec/templates/collection_partial', as: :name" }
       it { is_expected.to eq %q/[{"attribute":"foo"},{"attribute":"bar"}]/ }
     end
+
+    context 'when use subpartials' do
+      let(:template_body) { "json.array! [{id: 1, profile: {name: 'Foo'}},{id: 2, profile: {name: 'Bar'}}], partial: 'spec/templates/user', as: :user" }
+      it { is_expected.to eq %q/[{"id":1,"profile":{"name":"Foo"}},{"id":2,"profile":{"name":"Bar"}}]/ }
+    end
   end
 end


### PR DESCRIPTION
I'm using gem with grape and grape-jbuilder and I have bug.

`NameError - undefined local variable or method 'profile' for #<Grape::Endpoint:0x007ffb288d0b00>:`

My templates, `index.jbuilder`
```ruby
json.items do
  json.array! @items, partial: 'items/item', as: :item
end
```

`items/_item.jbuilder`
```ruby
json.id item.id
json.profile do |json|
  json.partial! 'users/profile', profile: item.user.profile
end
```

`users/_profile.jbuilder`
```ruby
json.(profile, :first_name, :last_name, :gender)
```