### PR TITLE
Make it compatible with Ruby's BasicObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ end
 template.render
 ```
 
+### Hanami
+
+Follow these steps:
+
+  1. Add `tilt-jbuilder` gem to your project.
+  1. Generate a template (eg: `apps/api/templates/events/index.json.jbuilder`)
+  1. Profit
+
 ## Contributing
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/spec/tilt-jbuilder_spec.rb
+++ b/spec/tilt-jbuilder_spec.rb
@@ -29,6 +29,11 @@ describe Tilt::JbuilderTemplate do
     "{\"author\":\"Anthony\"}".should == template.render(Object.new, :name => 'Anthony')
   end
 
+  it "should pass basic object locals" do
+    template = Tilt::JbuilderTemplate.new { "json.author name" }
+    "{\"author\":\"Anthony\"}".should == template.render(BasicObject.new, :name => 'Anthony')
+  end
+
   it "should evaluate in an object scope" do
     template = Tilt::JbuilderTemplate.new { "json.author @name" }
     scope = Object.new


### PR DESCRIPTION
Hi, I'm the author of Hanami, the web framework for Ruby.

Our gem `hanami-view` uses `tilt` to render templates. During the rendering process, the view passes to the `Tilt::Template` a scope which inherits from Ruby's `BasicObject`.

This decision was taken to avoid conflicts with methods defined by Ruby's `Object`, which had the result of shadowing methods in the scope. This is one example of the clash: https://github.com/hanami/view/issues/28

---

There are two devs who reported a bug both in [your repo](https://github.com/anthonator/tilt-jbuilder/issues/20) and in [ours](https://github.com/hanami/view/issues/124) as well, because our gems aren't compatible.

This PR aims to fix these problems, by making `tilt-jbuilder` compatible with `BasicObject`, and by consequence with Hanami.

Please consider to merge this, I believe that `tilt-jbuilder` can benefit from this, regardless the Hanami compatibility. Again, see https://github.com/hanami/view/issues/28 for a concrete example.

Thanks in advance for your time.

---

Fix: #20
